### PR TITLE
Setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,12 @@ class App(tornado.web.Application):
 
 def main():
     app = App(url_patterns, **settings)
+    http_server_ssl = tornado.httpserver.HTTPServer(app, ssl_options={
+        "certfile": "/etc/ssl/certs/server.crt",
+        "keyfile": "/etc/ssl/certs/server.key",
+    })
+    http_server_ssl.listen(443)
+
     http_server = tornado.httpserver.HTTPServer(app)
     http_server.listen(options.port)
 

--- a/confs/upstart
+++ b/confs/upstart
@@ -7,7 +7,8 @@ description "Testing virtualenv and upstart setup"
 
 env PYTHON_HOME=/srv/speechy_env
 
-start on filesystem and net-device-up IFACE!=lo
+# this is a vagrant specific event
+start on vagrant-mounted
 # start on runlevel [2345]
 stop on runlevel [!2345]
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,6 +8,10 @@
       notify:
         - start nginx
 
+    - name: create self-signed SSL cert
+      command: openssl req -new -nodes -x509 -subj "/C=US/ST=Oregon/L=Portland/O=IT/CN=${ansible_fqdn}" -days 3650 -keyout /etc/ssl/certs/server.key -out /etc/ssl/certs/server.crt -extensions v3_ca creates=/etc/ssl/certs/server.crt
+      notify: reload nginx
+
     - name: install python dev
       sudo: yes
       apt: pkg={{ item }} state=present

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,7 +4,7 @@
   sudo: yes
   tasks:
     - name: Installs nginx web server
-      apt: pkg=nginx state=installed update_cache=true
+      apt: pkg=nginx state=installed
       notify:
         - start nginx
 
@@ -27,6 +27,12 @@
         requirements: /srv/speechy/requirements.txt
         virtualenv: /srv/speechy_env
         virtualenv_python: python3.4
+
+    - name: Setup upstart
+      sudo: yes
+      command: cp /srv/speechy/confs/upstart /etc/init/speechy.conf
+
+    - file: path=/etc/init/speechy.conf owner=root group=root mode=0644
 
   handlers:
     - name: start nginx


### PR DESCRIPTION
additions:
- a basic upstart conf for easy testing on the vagrant boxes.  it should install itself on first `vagrant up` or subsequent `vagrant provision`.  We can swap this out for supervisord, but this will get it up and running for now.
- ssl is required for granting access to the microphone from the browser.  I'm just generating self-signed certs for the moment so we can test.  it seems like it's recommended to serve separate ports from separate instances, but we can investigate the best way to handle the multiple ports
